### PR TITLE
Mobile Layout Fixes

### DIFF
--- a/components/layout.module.scss
+++ b/components/layout.module.scss
@@ -11,6 +11,7 @@
     border-radius: 5px;
   }
   //optionally set height and width, it will depend on the rest of the styling used
+  height: 60px;
 }
 
 // .flex {

--- a/components/layout.module.scss
+++ b/components/layout.module.scss
@@ -10,8 +10,11 @@
     margin: 5px;
     border-radius: 5px;
   }
+  @include device-size(miniDevice) {
+    margin: 5px;
+    border-radius: 5px;
+  }
   //optionally set height and width, it will depend on the rest of the styling used
-  height: 60px;
 }
 
 // .flex {
@@ -26,9 +29,6 @@
   padding: 0 1rem;
   height: 100%;
   justify-content: center;
-  // @include device-size(phone) {
-  //   display: none;
-  // }
 }
 
 .menu {
@@ -47,9 +47,6 @@
 }
 
 .dateContainer {
-  // @extend .flex;
-  // padding: 10px 0 5px 0;
-  // border-top: 1px solid #3A3B3C;
   color: $secondary-text-color;
   font-size: 16px;
   @include device-size(phone) {
@@ -73,6 +70,10 @@
   @include device-size(phone) {
     grid-template-columns: 1fr;
     width: 100vw;
+    row-gap: 5px;
+  }
+
+  @include device-size(miniDevice) {
     row-gap: 5px;
   }
 

--- a/components/standings.module.scss
+++ b/components/standings.module.scss
@@ -8,6 +8,11 @@
     padding: 5px;
     margin: 5px;
   }
+
+  @include device-size(miniDevice) {
+    padding: 5px;
+    margin: 5px;
+  }
 }
 
 .league {

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,7 +5,7 @@ import Layout from '../components/layout';
 
 export default function Home() {
   const dateProp = new Date();
-  console.log(dateProp)
+  // console.log(dateProp)
   return (
     <>
       <Layout page={'index'} date={dateProp}>

--- a/styles/Home.module.scss
+++ b/styles/Home.module.scss
@@ -8,15 +8,16 @@
   justify-content: flex-start;
   @include device-size(phone) {
     justify-content: center;
-    min-height: 70vh;
+    // min-height: 70%;
   }
   align-items: center;
   margin: 2rem auto;
 }
 
 .main {
+  // min-height: 70%;
   padding: 5rem 0;
-  flex: 1;
+  // flex: 1;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -59,6 +60,9 @@
   margin: 0;
   line-height: 1.15;
   font-size: 3rem;
+  @include device-size(phone) {
+    font-size: 2rem;
+  }
 }
 
 .title,

--- a/styles/Home.module.scss
+++ b/styles/Home.module.scss
@@ -11,7 +11,7 @@
     // min-height: 70%;
   }
   align-items: center;
-  margin: 2rem auto;
+  margin: calc((100vh - 70px - 89px - 232px)/2) auto;
 }
 
 .main {
@@ -32,11 +32,14 @@
   color: $secondary-text-color;
   font-size: 20px;
   text-align: center;
-  width: 20vw;
+  width: 30vw;
   @include device-size(phone) {
-    width: 90vw;
+    width: 95vw;
   }
-  margin-bottom: 1rem;;
+  @include device-size(miniDevice) {
+    width: 95vw;
+  }
+  margin-bottom: 1rem;
 
   &:hover {
     color: $primary-text-color;
@@ -62,6 +65,9 @@
   font-size: 3rem;
   @include device-size(phone) {
     font-size: 2rem;
+  }
+  @include device-size(miniDevice) {
+    font-size: 1.75rem;
   }
 }
 

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -2,6 +2,8 @@
 @mixin device-size($device) {
   @if $device == phone {
     @media screen and (max-width: 600px) { @content; }
+  } @else if $device == miniDevice {
+    @media screen and (min-width: 601px) and (max-width: 767px) { @content; }
   } @else if $device == tablet {
     @media screen and (min-width: 768px) and (max-width: 991px) { @content; }
   } @else if $device == tablet-laptop {

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -6,7 +6,6 @@ body {
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
   color: $primary-text-color;
   background-color: $background-color;
-  height: 100%;
 }
 
 a {
@@ -55,8 +54,9 @@ footer {
 #__next {
   display: flex;
   flex-direction: column;
-  // height: 100vh;
-  height: 100%;
+  @include device-size(large-computer) {
+    height: 100vh;
+  }
   justify-content: space-between;
 }
 

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -6,6 +6,7 @@ body {
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
   color: $primary-text-color;
   background-color: $background-color;
+  height: 100%;
 }
 
 a {
@@ -26,6 +27,9 @@ footer {
   padding: 1rem 0 2rem;
   // margin-top: auto;
   margin: auto auto 0;
+  @include device-size(phone) {
+    margin: 0 auto 1rem;
+  }
   // align-content: center;
 
   ul {
@@ -51,7 +55,9 @@ footer {
 #__next {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  // height: 100vh;
+  height: 100%;
+  justify-content: space-between;
 }
 
 .score {


### PR DESCRIPTION
There was an issue with the layout on **MOBILE** devices due to the use of viewport height units that was being used. In order to fix it, the vh units had to be removed but they were useful for creating a beautiful layout on larger, non-mobile devices. Therefore, they were removed from mobile devices, but **ADDED** to larger devices using media queries.

Other minor changes, margins were added to the components on landscape-mode mobile phones to maintain a consistent design across phones.